### PR TITLE
JSONField Fix

### DIFF
--- a/djongo/utils.py
+++ b/djongo/utils.py
@@ -1,0 +1,17 @@
+def encode_keys(obj, is_key=False):
+    if isinstance(obj, dict):
+        return {encode_keys(k, True): encode_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [encode_keys(v) for v in obj]
+    if isinstance(obj, str) and is_key:
+        return obj.replace("\\", "\\\\").replace("\$", "\\u0024").replace(".", "\\u002e")
+    return obj
+
+def decode_keys(obj, is_key=False):
+    if isinstance(obj, dict):
+        return {decode_keys(k, True): decode_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [decode_keys(v) for v in obj]
+    if isinstance(obj, str) and is_key:
+        return obj.replace("\\u002e", ".").replace("\\u0024", "\$").replace("\\\\", "\\")
+    return obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sqlparse>=0.2.4
+sqlparse==0.4.1
 pymongo>=3.2.0
 django>=2.1
 dnspython>=2.0


### PR DESCRIPTION
To escape special characters like $, . and \ for JSON field keys, pymongo/bson complains that it's not allowed

and locking sqlparse version.