### PR TITLE
Implement JSONField lookups + fix broken discovery page

### DIFF
--- a/djongo/models/fields.py
+++ b/djongo/models/fields.py
@@ -144,6 +144,9 @@ class JSONField(MongoField):
             return transform
         return KeyTransformFactory(name)
 
+    def value_to_string(self, obj):
+        return self.value_from_object(obj)
+
 
 class DjongoOperatorLookup(FieldGetDbPrepValueMixin, Lookup):
     djongo_operator = None

--- a/djongo/models/fields.py
+++ b/djongo/models/fields.py
@@ -25,6 +25,7 @@ from django.db import router, connections, transaction
 from django.db.models import (
     Manager, Model, Field, AutoField,
     ForeignKey, BigAutoField)
+from django.db.models.lookups import Transform, FieldGetDbPrepValueMixin, Lookup
 from django.utils import version
 from django.db.models.fields.related import RelatedField
 from django.forms import modelform_factory
@@ -82,11 +83,42 @@ class MongoField(Field):
     empty_strings_allowed = False
 
 
+class KeyTransform(Transform):
+    def __init__(self, key_name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.key_name = str(key_name)
+
+    def preprocess_lhs(self, compiler, connection):
+        key_transforms = [self.key_name]
+        previous = self.lhs
+        while isinstance(previous, KeyTransform):
+            key_transforms.insert(0, previous.key_name)
+            previous = previous.lhs
+        lhs, params = compiler.compile(previous)
+        return lhs, params, key_transforms
+
+    def as_djongo(self, compiler, connection):
+        lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
+        dot_lookups = '.'.join([f'"{s}"' for s in key_transforms])
+        return '%s.%s' % (lhs, dot_lookups), []
+
+
+class KeyTransformFactory:
+    def __init__(self, key_name):
+        self.key_name = key_name
+
+    def __call__(self, *args, **kwargs):
+        return KeyTransform(self.key_name, *args, **kwargs)
+
+
 class JSONField(MongoField):
     def get_prep_value(self, value):
+        if value is None:
+            return 'null'
+
         if not isinstance(value, (dict, list, str)):
             raise ValueError(
-                f'Value: {value} must be of type dict/list, instead got type {type(value)}'
+                f'Value: {value} must be of type dict/list/str, instead got type {type(value)}'
             )
         # Fix for special characters in keys.
         # See: https://stackoverflow.com/a/30254815
@@ -105,6 +137,70 @@ class JSONField(MongoField):
         if isinstance(value, dict):
             value = decode_keys(value)
         return value
+
+    def get_transform(self, name):
+        transform = super().get_transform(name)
+        if transform:
+            return transform
+        return KeyTransformFactory(name)
+
+
+class DjongoOperatorLookup(FieldGetDbPrepValueMixin, Lookup):
+    djongo_operator = None
+
+    def as_djongo(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        params = tuple(lhs_params) + tuple(rhs_params)
+        return '%s %s %s' % (lhs, self.djongo_operator, rhs), params
+
+
+class DataContains(DjongoOperatorLookup):
+    lookup_name = 'contains'
+    djongo_operator = '$contains'
+
+
+class HasKeyLookup(DjongoOperatorLookup):
+    def as_djongo(self, compiler, connection):
+        if isinstance(self.rhs, KeyTransform):
+            *_, rhs_key_transforms = self.rhs.preprocess_lhs(compiler, connection)
+            for key in rhs_key_transforms[:-1]:
+                self.lhs = KeyTransform(key, self.lhs)
+            self.rhs = rhs_key_transforms[-1]
+        return super().as_djongo(compiler, connection)
+
+
+class HasKey(HasKeyLookup):
+    lookup_name = 'has_key'
+    djongo_operator = '$has_key'
+    prepare_rhs = False
+
+
+class HasKeys(HasKeyLookup):
+    lookup_name = 'has_keys'
+    djongo_operator = '$has_keys'
+
+    def get_prep_lookup(self):
+        return [str(item) for item in self.rhs]
+
+
+class HasAnyKeys(HasKeys):
+    lookup_name = 'has_any_keys'
+    djongo_operator = '$has_any_keys'
+
+
+class JSONExact(DjongoOperatorLookup):
+    lookup_name = 'exact'
+    djongo_operator = '$exact'
+    can_use_none_as_rhs = True
+
+
+JSONField.register_lookup(DataContains)
+JSONField.register_lookup(HasKey)
+JSONField.register_lookup(HasKeys)
+JSONField.register_lookup(HasAnyKeys)
+JSONField.register_lookup(JSONExact)
+
 
 class ModelField(MongoField):
     """

--- a/djongo/sql2mongo/operators.py
+++ b/djongo/sql2mongo/operators.py
@@ -417,7 +417,7 @@ class _StatementParser:
 
         elif isinstance(tok, Identifier):
             t = statement.next_token
-            if not t or isinstance(t, Parenthesis):
+            if not t or t.match(tokens.Punctuation, (')', '(')):
                 op = ColOp(tok, self.query)
         else:
             raise SQLDecodeError

--- a/djongo/sql2mongo/operators.py
+++ b/djongo/sql2mongo/operators.py
@@ -2,12 +2,11 @@ import re
 import typing
 from itertools import chain
 
-from sqlparse import parse as sqlparse
 from sqlparse import tokens
 from sqlparse.sql import Token, Parenthesis, Comparison, IdentifierList, Identifier
 
 from . import query
-from .sql_tokens import SQLToken, SQLStatement, SQLComparison
+from .sql_tokens import SQLToken, SQLStatement
 from ..exceptions import SQLDecodeError
 
 
@@ -365,6 +364,9 @@ class _StatementParser:
                   statement: SQLStatement) -> '_Op':
         op = None
         kw = {'statement': statement, 'query': self.query}
+        if tok.match(tokens.Name.Placeholder, '%(.+)s', regex=True):
+            return op
+
         if tok.match(tokens.Keyword, 'AND'):
             op = AndOp(**kw)
 
@@ -394,6 +396,9 @@ class _StatementParser:
         elif tok.match(tokens.Keyword, 'IS'):
             op = IsOp(**kw)
 
+        elif tok.value in JSON_OPERATORS:
+            op = JSONOp(**kw)
+
         elif isinstance(tok, Comparison):
             op = CmpOp(tok, self.query)
 
@@ -412,7 +417,7 @@ class _StatementParser:
 
         elif isinstance(tok, Identifier):
             t = statement.next_token
-            if not t or not t.match(tokens.Keyword, ('LIKE', 'iLIKE', 'BETWEEN', 'IS', "IN")):
+            if not t or isinstance(t, Parenthesis):
                 op = ColOp(tok, self.query)
         else:
             raise SQLDecodeError
@@ -555,6 +560,52 @@ class ColOp(_Op):
         pass
 
 
+class JSONOp(_Op):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._identifier = self.statement.prev_token.value
+        self._operator = self.statement.current_token.value
+        index = re_index(self.statement.next_token.value)
+        self._constant = self.params[index] if index is not None else None
+
+    def negate(self):
+        self.is_negated = True
+
+    def to_mongo(self):
+        field = '.'.join([f[1:-1] for f in self._identifier.split('.')[1:]])
+
+        if self._operator == '$exact':
+            op = '$eq' if not self.is_negated else '$ne'
+            return {field: {op: self._constant}}
+
+        elif self._operator == '$contains':
+            if isinstance(self._constant, dict):
+                return {f'{field}.{k}': self._constant[k] for k in self._constant}
+            elif isinstance(self._constant, list):
+                return {field: {'$all': self._constant}}
+            else:
+                raise SQLDecodeError(f'Invalid params for $contains: {self._constant}')
+
+        elif self._operator == '$has_key':
+            return {f'{field}.{self._constant}': {'$exists': not self.is_negated}}
+
+        elif self._operator == '$has_keys':
+            return {f'{field}.{const}': {'$exists': not self.is_negated} for const in self._constant}
+
+        elif self._operator == '$has_any_keys':
+            return {
+                '$or': [{f'{field}.{const}': {'$exists': not self.is_negated}} for const in self._constant]
+            }
+
+        else:
+            raise SQLDecodeError(f'Invalid JSONOp: {self._operator}')
+
+    def evaluate(self):
+        pass
+
+
+JSON_OPERATORS = ['$exact', '$contains', '$has_key', '$has_keys', '$has_any_keys']
 OPERATOR_MAP = {
     '=': '$eq',
     '>': '$gt',


### PR DESCRIPTION
- Implemented JSONField lookups
- Also, fixed the broken discovery page: it was due to an issue with _BinaryOp. The fix in the previous PR https://github.com/morbitech1/djongo/commit/ea43ee80740c11cf223b273b84305c83855ae1b0#diff-3d1430fd7337777e6b87c162eb16e800cb15340aee5a0fa80401904ddfc5f50bR78 was incomplete. When the token is parsed as a `SQLComparison`, the `left_column` is stored as the _BinaryOp's field (e.g. "trial"). However, what we needed to store was the fully qualified field (e.g. "study_study.trial"). This was causing some WHERE conditions to incorrectly fail as the field was not found.